### PR TITLE
Fixed bug removing characters from filename

### DIFF
--- a/uma/src/umaexttool/standalone.py
+++ b/uma/src/umaexttool/standalone.py
@@ -79,7 +79,7 @@ def run(arglist: list[str]):
     xyzname, charge, mult, ncores, dograd = common.read_input(args.inputfile)
 
     # set filenames
-    basename = xyzname.rstrip(".xyz")
+    basename = xyzname.removesuffix(".xyz")
     orca_engrad = basename + ".engrad"
 
     # process the XYZ file


### PR DESCRIPTION
rstrip(".xyz") not only removes ".xyz" from the end of the filename, but any characters from the specified set that might be present at the right end of the string. For example, "file_x.xyz" would be stripped to "file_".