### PR TITLE
Fixing deprecated pkg_resources

### DIFF
--- a/requirements/uma.txt
+++ b/requirements/uma.txt
@@ -1,1 +1,2 @@
+setuptools<82.0.0
 fairchem-core>=2.2.0


### PR DESCRIPTION
With `setuptools` version 82.0.0 and newer, the current `fairchem` package, and therefore UMA, no longer works due to the deprecation of `pkg_resources`. This fix ensures that a `setuptools` version lower than 82.0.0 is installed when `fairchemcore` is installed.

Closes #30.