### PR TITLE
Fix: No search for MLatom in the virtual environment

### DIFF
--- a/install.py
+++ b/install.py
@@ -149,7 +149,7 @@ def install_dev_tools(venv_dir: Path) -> None:
     pip_path = get_venv_pip(venv_dir)
 
     print("Installing developer tools.")
-    subprocess.check_call([pip_path, "install", ".[dev]"])
+    subprocess.check_call([pip_path, "install", "-e", ".[dev]"])
 
 
 def copy_oet_scripts(venv_dir: Path, dest_dir: Path, extras: Sequence[str]) -> None:

--- a/requirements/mlatom.txt
+++ b/requirements/mlatom.txt
@@ -1,3 +1,5 @@
+# Torch currently requires setuptools<82.
+setuptools<82.0.0
 mlatom>=3.12.0
 torchani==2.2.4
 joblib>=1.5.3

--- a/requirements/mlatom.txt
+++ b/requirements/mlatom.txt
@@ -1,2 +1,3 @@
-mlatom>=2.0.3
+mlatom>=3.12.0
 torchani==2.2.4
+joblib>=1.5.3

--- a/src/oet/calculator/mace.py
+++ b/src/oet/calculator/mace.py
@@ -170,8 +170,8 @@ class MaceCalc(BaseCalc):
                 "This requires the installation of torch_dftd to the virtual "
                 "environment and that liblzma was installed when setting up "
                 "the environment."
-            )
-            )
+            ),
+        )
         parser.add_argument(
             "--damping",
             type=str,

--- a/src/oet/calculator/mlatom.py
+++ b/src/oet/calculator/mlatom.py
@@ -34,8 +34,10 @@ main: function
 
 import os
 import shutil
+import sys
 import tempfile
 from argparse import ArgumentParser
+from pathlib import Path
 from typing import Any
 
 from oet.core.base_calc import BaseCalc, CalculationData
@@ -45,8 +47,35 @@ from oet.core.misc import LENGTH_CONVERSION, check_path, run_command
 class MlatomCalc(BaseCalc):
     @property
     def PROGRAM_NAMES(self) -> list[str]:
-        """Program names to search for in PATH"""
-        return ["mlatom"]
+        """
+        Program names/paths to search for.
+
+        Returns
+        -------
+        list[str]
+            A list of paths or names to be searched for in PATH.
+        """
+        exe_names = ["mlatom"]
+
+        candidates: list[str] = []
+
+        # Program names to be searched in the PATH.
+        candidates.extend(exe_names)
+
+        # Directories in the current python environments to check
+        # Include "Scripts" to catch Windows installations
+        bin_dirs = [
+            Path(sys.prefix) / "bin",
+            Path(sys.prefix) / "Scripts",
+            Path(sys.executable).parent,
+        ]
+
+        # Add possible full Paths of the program
+        for bindir in bin_dirs:
+            for name in exe_names:
+                candidates.append(str(bindir / name))
+
+        return candidates
 
     @classmethod
     def extend_parser(cls, parser: ArgumentParser) -> None:

--- a/tests/aimnet2/test_aiment2_v02_contract.py
+++ b/tests/aimnet2/test_aiment2_v02_contract.py
@@ -435,7 +435,6 @@ class TestBaseCalcReleaseDefault:
     """
 
     def test_release_default_is_callable_and_no_op(self):
-
         from oet.core.base_calc import BaseCalc
 
         class _StubCalc(BaseCalc):

--- a/tests/mlatom/test_mlatom.py
+++ b/tests/mlatom/test_mlatom.py
@@ -98,9 +98,9 @@ class MLatomTests(unittest.TestCase):
             ) from e
 
         self.assertEqual(num_atoms, expected_num_atoms)
-        self.assertAlmostEqual(energy, expected_energy, places=9)
+        self.assertAlmostEqual(energy, expected_energy, places=7)
         for g1, g2 in zip(gradients, expected_gradients):
-            self.assertAlmostEqual(g1, g2, places=9)
+            self.assertAlmostEqual(g1, g2, places=7)
 
     def test_OH_anion_eng_grad(self):
         xyz_file, input_file, engrad_out, output_file = get_filenames("OH_anion")
@@ -133,9 +133,9 @@ class MLatomTests(unittest.TestCase):
             ) from e
 
         self.assertEqual(num_atoms, expected_num_atoms)
-        self.assertAlmostEqual(energy, expected_energy, places=9)
+        self.assertAlmostEqual(energy, expected_energy, places=7)
         for g1, g2 in zip(gradients, expected_gradients):
-            self.assertAlmostEqual(g1, g2, places=9)
+            self.assertAlmostEqual(g1, g2, places=7)
 
     def test_OH_rad_eng_grad(self):
         xyz_file, input_file, engrad_out, output_file = get_filenames("OH_rad")
@@ -168,9 +168,9 @@ class MLatomTests(unittest.TestCase):
             ) from e
 
         self.assertEqual(num_atoms, expected_num_atoms)
-        self.assertAlmostEqual(energy, expected_energy, places=9)
+        self.assertAlmostEqual(energy, expected_energy, places=7)
         for g1, g2 in zip(gradients, expected_gradients):
-            self.assertAlmostEqual(g1, g2, places=9)
+            self.assertAlmostEqual(g1, g2, places=7)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
- fix: Without an MLatom executable in the `$PATH`, the respective `oet_mlatom` script didn't work, even though MLatom was available in the installed virtual environment. With this fix, the MLatom executable is now searched also for in the respective virtual environment.
- fix: Installing the `dev` features during the setup of the virtual environment is now done in editable mode similar to the standard installation.
- build: bump MLatom dependency from 2.0.3 to 3.12.0.