### PR TITLE
fix: fix filename for xyz input file

### DIFF
--- a/src/oet/core/misc.py
+++ b/src/oet/core/misc.py
@@ -282,7 +282,7 @@ def read_input(
         raise FileNotFoundError(f"Input file not found: {inputfile}")
     # Save information
     try:
-        xyz_filename = lines[0]
+        xyz_filename = Path(lines[0]).name
         charge = int(lines[1])
         multiplicity = int(lines[2])
         ncores = int(lines[3])


### PR DESCRIPTION
The filename for the xyz file is a plain string but there were no checks whether it was actually a Path. I call `Path(xyz_filename).name` on it to make sure that it is an actual file name and not a path.